### PR TITLE
close #6 [管理者用 quiz level 一覧画面] quiz level を複数選択して削除できるようにする機能を追加

### DIFF
--- a/src/views/admin/quiz-level/index.vue
+++ b/src/views/admin/quiz-level/index.vue
@@ -17,71 +17,81 @@
       :search='search'
       :loading="loading"
       loading-text="Loading... Please wait"
+      item-key="ID"
+      show-select
+      v-model="selectedItems"
     >
       <template v-slot:top>
-        <v-spacer></v-spacer>
         <v-toolbar flat>
+          <v-btn
+            small
+            color="error"
+            @click="deleteItems"
+            :disabled="!deleteBtn"
+          >
+            Delete Quiz Titles
+          </v-btn>
+          <v-spacer></v-spacer>
           <v-dialog
             v-model="dialog"
             max-width="600px"
           >
-            <template v-slot:activator="{ on, attrs }">
+          <template v-slot:activator="{ on, attrs }">
+            <v-btn
+              small
+              color="primary"
+              class="mb-2"
+              v-bind="attrs"
+              v-on="on"
+            >
+              New
+            </v-btn>
+          </template>
+          <v-card>
+            <v-card-title>
+              <span class="text-h5">{{ formTitle }}</span>
+            </v-card-title>
+
+            <v-card-text>
+              <v-container>
+                  <ErrorMessages :errorMessages=errorMessages></ErrorMessages>
+                  <v-form ref="form">
+                    <MyInput
+                      v-model="editedItem.Name"
+                      label="Name"
+                      v-bind="nameRules"
+                    />
+                  </v-form>
+              </v-container>
+            </v-card-text>
+
+            <v-card-actions>
               <v-spacer></v-spacer>
               <v-btn
-                small
-                color="primary"
-                class="mb-2"
-                v-bind="attrs"
-                v-on="on"
+                color="blue darken-1"
+                text
+                @click="close"
               >
-                New
+                Cancel
               </v-btn>
-            </template>
-            <v-card>
-              <v-card-title>
-                <span class="text-h5">{{ formTitle }}</span>
-              </v-card-title>
-
-              <v-card-text>
-                <v-container>
-                    <ErrorMessages :errorMessages=errorMessages></ErrorMessages>
-                    <v-form ref="form">
-                      <MyInput
-                        v-model="editedItem.Name"
-                        label="Name"
-                        v-bind="nameRules"
-                      />
-                    </v-form>
-                </v-container>
-              </v-card-text>
-
-              <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn
-                  color="blue darken-1"
-                  text
-                  @click="close"
-                >
-                  Cancel
-                </v-btn>
-                <v-btn
-                  v-if="editedIndex != -1"
-                  color="blue darken-1"
-                  text
-                  @click="update"
-                >
-                  Update
-                </v-btn>
-                <v-btn
-                  v-if="editedIndex === -1"
-                  color="blue darken-1"
-                  text
-                  @click="create"
-                >
-                  Create
-                </v-btn>
-              </v-card-actions>
-            </v-card>
+              <v-btn
+                v-if="editedIndex != -1"
+                color="blue darken-1"
+                text
+                @click="update"
+              >
+                Update
+              </v-btn>
+              <v-btn
+                v-if="editedIndex === -1"
+                color="blue darken-1"
+                text
+                @click="create"
+              >
+                Create
+              </v-btn>
+            </v-card-actions>
+          </v-card>
           </v-dialog>
           <v-dialog v-model="dialogDelete" max-width="500px">
             <v-card>
@@ -89,7 +99,7 @@
               <v-card-actions>
                 <v-spacer></v-spacer>
                 <v-btn color="blue darken-1" text @click="closeDelete">Cancel</v-btn>
-                <v-btn color="blue darken-1" text @click="deleteItemConfirm(editedItem)">OK</v-btn>
+                <v-btn color="blue darken-1" text @click="deleteItemsConfirm()">OK</v-btn>
                 <v-spacer></v-spacer>
               </v-card-actions>
             </v-card>
@@ -118,13 +128,6 @@
           @click="editItem(item)"
         >
           mdi-pencil
-        </v-icon>
-        <v-icon
-          small
-          color="red"
-          @click="deleteItem(item)"
-        >
-          mdi-delete
         </v-icon>
       </template>
     </v-data-table>
@@ -168,8 +171,8 @@ export default {
             sortable: false
         }
       ],
-      quizLevels: [],
       search: '',
+      selectedItems: [],
       dialog: false,
       dialogDelete: false,
       editedIndex: -1,
@@ -183,6 +186,7 @@ export default {
         max: 40,
         required: true
       },
+      quizLevels: [],
       errorMessages: []
     }
   },
@@ -190,6 +194,12 @@ export default {
     formTitle () {
       return this.editedIndex === -1 ? 'New' : 'Edit'
     },
+    deleteBtn () {
+      return this.selectedItems.length
+    },
+    deleteQuizTitleIds () {
+      return this.selectedItems.map(item => item.ID)
+    }
   },
   watch: {
     dialog (val) {
@@ -227,22 +237,29 @@ export default {
       this.editedItem = Object.assign({}, item)
       this.dialog = true
     },
-    deleteItem (item) {
-      this.editedIndex = this.quizLevels.indexOf(item)
-      this.editedItem = Object.assign({}, item)
+    deleteItems () {
       this.dialogDelete = true
     },
-    deleteItemConfirm (item) {
-      this.$adminHttp.delete(`/admin/quiz_levels/${item.ID}`)
+    deleteItemsConfirm () {
+      const selectedQuizLevelIds = this.selectedItems.map(item => item.ID)
+      this.$adminHttp.request({
+        method: 'delete',
+        url: "/admin/quiz_levels",
+        data: { QuizLevelIds: selectedQuizLevelIds }
+      })
         .then(response => {
           if (response.data != null) {
             console.log(response.data)
             this.setFlashMessage({ type: 'warning', message: "Failed to delete ..."})
           } else {
-            this.quizLevels.splice(this.editedIndex, 1)
-            this.closeDelete()
-            this.setFlashMessage({ type: 'success', message: "Delete successfully"})
+          this.quizLevels = this.quizLevels.filter( function (item) {
+            return selectedQuizLevelIds.includes(item.ID) === false
+          })
           }
+          this.closeDelete()
+          this.setFlashMessage({
+            type: 'success', message: "Delete successfully"
+          })
         })
         .catch(error => {
           console.log(error)


### PR DESCRIPTION
### 変更概要

quiz level を複数選択して削除できるようにする機能を追加

### 変更理由

1. 複数選択で削除できることにより、UXが向上する
2. サーバー通信を減らすことができる

### 変更内容

1. quiz level 一覧テーブルの各行の一番左にチェックポックスを追加
2. quiz level 一覧テーブルの項目行に一括選択のチェックボックスを追加
3. チェックされた場合のみ有効となる delete quiz level ボタンを追加
4. quiz level 一覧テーブルの右端にあった個別の削除ボタンを削除
5. deleteメソッドでも値を request body に入れられるように記述を変更
(参考: https://teratail.com/questions/296013)

### 変更されたページのスクリーンショット

![スクリーンショット 2021-07-17 6 17 01](https://user-images.githubusercontent.com/48712267/126009395-963c17c6-ee06-4d33-815d-a7ca795ac1b0.png)
