### PR TITLE
Modify method for parse query paramater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,31 @@
+<<<<<<< Updated upstream
 node_modules
+=======
+<<<<<<< HEAD
+.DS_Store
+node_modules
+/dist
+
+
+# local env files
+.env.local
+.env.*.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.slnろ
+*.sw?
+=======
+node_modules
+>>>>>>> 995a871074ccf2cfdcde10b871e7a9c342dc5da3
+>>>>>>> Stashed changes

--- a/src/components/parts/form/MySelect.vue
+++ b/src/components/parts/form/MySelect.vue
@@ -16,7 +16,7 @@
 export default {
   name: "MySelect",
   props: {
-    value: { type: [Number, Array], required: true },
+    value: { type: [ Number, Array ], required: true },
     items: { type: Array },
     itemText: { type: String },
     itemValue: { type: String},
@@ -27,7 +27,7 @@ export default {
   computed: {
     selectValue: {
       get() {
-        return Number(this.value)
+        return this.value
       },
       set(value) {
         this.$emit("input", value)

--- a/src/mixins/globalMethods.js
+++ b/src/mixins/globalMethods.js
@@ -104,14 +104,23 @@ export default {
     ParseQueryAndSetSearchConditions () {
       const params = this.$route.query
       let queryParams = Object.assign({}, params)
-      const keys = ['selectedQuizLevelIDs', 'selectedQuizSectionsIDs', 'selectedQuizTitlesIDs', 'page']
-      keys.forEach(key => {
+      const selectedIDsKeys = [
+        'selectedQuizLevelIDs',
+        'selectedQuizSectionsIDs',
+        'selectedQuizTitlesIDs',
+      ]
+      selectedIDsKeys.forEach(key => {
         if (Array.isArray(queryParams[key])) {
           queryParams[key] = queryParams[key].map(Number)
         } else if (queryParams[key] != null){
           queryParams[key] = [Number(queryParams[key])]
         }
       })
+      const paginationKeys = ["page", "pageSize"]
+      paginationKeys.forEach(key => {
+        queryParams[key] = Number(queryParams[key])
+      })
+      console.log("pageSize is")
       Object.assign(this.searchConditions, queryParams)
     },
     ClearSearchConditions () {

--- a/src/views/admin/quiz-title/index.vue
+++ b/src/views/admin/quiz-title/index.vue
@@ -2,11 +2,11 @@
   <div>
     <v-card class="px-2 pt-2">
       <v-card-title>
-        Quiz Titles
         <v-divider
-          class="mx-4"
+          class="mr-4"
           vertical
         ></v-divider>
+        Quiz Titles
         <v-spacer></v-spacer>
         <div align="right">
           <p class="mb-0">
@@ -453,9 +453,13 @@ export default {
     editItem (item) {
       this.editedItem = Object.assign({}, item)
       this.editedIndex = this.tableData.indexOf(item)
-      this.editedItem.QuizLevelID = item.QuizSection.QuizLevel.ID
-      this.editedItem.QuizSectionID = item.QuizSection.ID
-      this.setQuizSectionsForSelect('quizSections', this.editedItem)
+      this.editedItem.QuizLevelID = item.QuizLevelID
+      this.editedItem.QuizSectionID = item.QuizSectionID
+      this.SetCategoryOptionsForSelect(
+        'admin/quiz_sections/get_by_quiz_level_ids',
+        'quizSections',
+        item.QuizLevelID
+      )
       this.dialog = true
     },
     close () {


### PR DESCRIPTION
### 問題点
セレクトフィールドコンポーネントを複数選択、単一選択の両方対応できるものに変更した際に、props値として受け取ったものを全てnumberの配列型に変換する処理に変えてしまった。
その変更により、単一選択のセレクトフィールドとしてコンポーネントを使用した際に、propsで渡したvalue値が配列型に変換されてしまうためにエラーとなっていた。

### 修正点
セレクトフィールドのコンポーネント側でprops値を配列型にする変更する処理をなくした。
複数選択なら配列型、単一選択ならnumber型に値を変換してからコンポーネント側に渡すようにした。



