### PR TITLE
修正：管理画面にある削除ボタンを押下後、削除ボタンが有効のままであるバグ

### DIFF
--- a/src/components/parts/dataTable/MyDataTable.vue
+++ b/src/components/parts/dataTable/MyDataTable.vue
@@ -391,6 +391,8 @@ export default {
           this.tableData = this.tableData.filter( function (item) {
             return selectedItemIds.includes(item.ID) === false
           })
+          this.itemsTotalCount -= this.selectedItems.length
+          this.selectedItems = []
           this.setFlashMessage({
             type: 'success', message: 'Remove quizzes successfully'
           })


### PR DESCRIPTION
## 修正概要
管理画面に削除したいアイテムを選択すると有効になる削除ボタンがある。
しかし、アイテムが削除された後ボタンが無効状態に戻らない状態だったため、これを無効に戻るように修正した。

### 修正理由 
削除ボタンを押すと確認のためのポップアップが出てくるが、全選択ボタンもあるため誤って削除しないように
ユーザーには選択されているアイテムがあるかないのかを一目でわかるようにした方がいいと考えたため。

### 原因
アイテムを選択すると、アイテムの ID  が selectedItems に格納される。
削除ボタンは selectedItems にある ID が 1個以上の場合、有効になる。
しかし、アイテムは削除されても、selectedItems に格納されている値を削除していなかったため、
まだアイテムを選択している状態となり、ボタンが有効のままとなっていた。

### 修正内容
アイテム削除が成功した後、selectedItems の値を空にする処理を追加


