### PR TITLE
修正: スクロールするとフラッシュメッセージの表示が確認できない不具合の修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,11 @@
 <template>
   <v-app style="min-width: 320px">
+    <FlashMessage />
     <Header />
     <v-main
       style="background-color: #F9FBFE;"
       class="pt-sm-5 main_wrapper"
     >
-      <FlashMessage />
       <v-container fluid>
         <router-view/>
       </v-container>
@@ -36,6 +36,9 @@ export default {
 <style>
 @import "./css/reset.css";
 .main_wrapper {
+  position: relative;
+}
+.v-application {
   position: relative;
 }
 </style>

--- a/src/components/globals/FlashMessage.vue
+++ b/src/components/globals/FlashMessage.vue
@@ -1,6 +1,6 @@
 <template>
   <v-alert
-    v-show="flashMessage"
+    v-if="flashMessage"
     dense
     border="left"
     :color="messageColor"
@@ -36,9 +36,9 @@ export default {
 
 <style scoped>
 .flash_message {
-  position: absolute;
+  position: fixed;
   z-index: 10;
-  top: -10px;
+  top: 30px;
   right: 10px;
 }
 </style>


### PR DESCRIPTION
## チケットへのリンク
<!-- #12 -->
#20


## やったこと

<!-- このプルリクで何をしたのか？ -->
フラッシュメッセージに対する css を変更

## やらないこと

<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
なし

## できるようになること（ユーザ目線）
スクロールした位置からでも、画面上部に表示されるフラッシュメッセージを確認できる。
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## できなくなること（ユーザ目線）
無し
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
管理画面の quiz title 一覧ページにて、スクロールした位置で、削除ボタンを押下。
画面上部にフラッシュメッセージを確認できた。

## UI変更
### 変更前
ページ上部までスクロールしないとフラッシュメッセージが確認できない。
![flashMessage2](https://user-images.githubusercontent.com/48712267/131235245-73ef4925-f590-44a7-b0fa-3b89a6654ef5.gif)

### 変更後
どの位置からでもフラッシュメッセージが画面上部に表示され確認できる。
![flashMessage](https://user-images.githubusercontent.com/48712267/131235130-dd757d47-d488-41f5-ba56-33febe32a719.gif)


## その他
無し
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
