### PR TITLE
[update] close #23 quiz section 一覧ページにテーブルコンポーネントを適応させる

### DIFF
--- a/src/views/admin/quiz-section/index.vue
+++ b/src/views/admin/quiz-section/index.vue
@@ -1,349 +1,134 @@
 <template>
-  <v-card>
-    <v-card-title>
-      Quiz Sections
-    </v-card-title>
-    <v-data-table
-      :headers="headers"
-      :items="quizSections"
-      :sort-by="headers"
-      :loading="loading"
-      loading-text="Loading... Please wait"
-      item-key="ID"
-      show-select
-      v-model="selectedItems"
-
-    >
-      <template v-slot:top>
-        <v-toolbar flat>
-          <v-btn
-            small
-            color="error"
-            @click="deleteItems"
-            :disabled="!deleteBtn"
-          >
-            Delete Quiz Sections
-          </v-btn>
-          <v-spacer></v-spacer>
-          <v-dialog
-            v-model="dialog"
-            max-width="600px"
-          >
-            <template v-slot:activator="{ on, attrs }">
-              <v-btn
-                small
-                color="primary"
-                v-bind="attrs"
-                v-on="on"
-              >
-                New
-              </v-btn>
-            </template>
-            <v-card>
-              <v-card-title>
-                <span class="text-h5">{{ formTitle }} Quiz Section</span>
-              </v-card-title>
-              <v-card-text>
-                <v-container>
-                  <ErrorMessages :errorMessages=errorMessages></ErrorMessages>
-                  <v-form ref="form">
-                    <MySelect
-                      v-model="editedItem.QuizLevelID"
-                      label="Quiz Level"
-                      :items="quizLevels"
-                      itemText="Name"
-                      itemValue="ID"
-                      v-bind="quizLevelRules"
-                    />
-                    <MyInput
-                      v-model="editedItem.Name"
-                      label="Name"
-                      v-bind="nameRules"
-                    />
-                  </v-form>
-                </v-container>
-              </v-card-text>
-
-              <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn
-                  color="blue darken-1"
-                  text
-                  @click="close"
-                >
-                  Cancel
-                </v-btn>
-                <v-btn
-                  v-if="editedIndex != -1"
-                  color="blue darken-1"
-                  text
-                  @click="update"
-                >
-                  Update
-                </v-btn>
-                <v-btn
-                  v-if="editedIndex === -1"
-                  color="blue darken-1"
-                  text
-                  @click="create"
-                >
-                  create
-                </v-btn>
-              </v-card-actions>
-            </v-card>
-          </v-dialog>
-          <v-dialog v-model="dialogDelete" max-width="600px">
-            <v-card>
-              <v-card-title class="text-h5">Are you sure you want to delete this item?</v-card-title>
-              <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn color="blue darken-1" text @click="closeDelete">Cancel</v-btn>
-                <v-btn color="blue darken-1" text @click="deleteItemsConfirm">OK</v-btn>
-                <v-spacer></v-spacer>
-              </v-card-actions>
-            </v-card>
-          </v-dialog>
-        </v-toolbar>
-      </template>
-      <template v-slot:item.CreatedAt="{ item }" v-slot:activator="{ChangeFormat}">
-        {{ ChangeFormat(item.CreatedAt, 'yyyy/M/d H:m') }}
-      </template>
-      <template v-slot:item.UpdatedAt="{ item }" v-slot:activator="{ChangeFormat}">
-        {{ ChangeFormat(item.UpdatedAt, 'yyyy/M/d H:m') }}
-      </template>
-      <template v-slot:item.actions="{ item }">
-        <router-link :to="{ name: 'ShowQuizSection', params: { id: item.ID }}">
-          <v-icon
-            small
-            class="mr-2"
-          >
-            mdi-open-in-new
-          </v-icon>
-        </router-link>
-        <v-icon
-          small
-          class="mr-2"
-          color="primary"
-          @click="editItem(item)"
-        >
-          mdi-pencil
-        </v-icon>
-      </template>
-
-    </v-data-table>
-  </v-card>
+  <MyDataTable
+    title="Quiz Section"
+    v-model="searchConditions"
+    :defaultSearchConditions="defaultSearchConditions"
+    :headers="headers"
+    url="quiz_sections"
+    linkName="showQuizSection"
+    :editedItem.sync="editedItem"
+    :defaultItem="defaultItem"
+    :initQuizLevels="initQuizLevels"
+    :updateEditedItem="updateEditedItem"
+  >
+    <template v-slot:search>
+      <MySelect
+        v-model="searchConditions.selectedQuizLevelIDs"
+        label="Quiz Level"
+        :items="quizLevels"
+        itemText="Name"
+        itemValue="ID"
+        multiple
+        chips
+        clearable
+      />
+    </template>
+    <template v-slot:form>
+      <MySelect
+        v-model="editedItem.QuizLevelID"
+        label="Quiz Level"
+        :items="quizLevels"
+        itemText="Name"
+        itemValue="ID"
+      />
+      <MyInput
+        v-model="editedItem.Name"
+        label="Name"
+        v-bind="nameRules"
+      />
+    </template>
+  </MyDataTable>
 </template>
 
 <script>
-import { mapActions } from 'vuex'
-import MyInput from '../../../components/parts/form/MyInput'
-import MySelect from '../../../components/parts/form/MySelect'
-import ErrorMessages from '../../../components/parts/ErrorMessages'
 import mixin from '../../../mixins/globalMethods.js'
+import MyDataTable from '../../../components/parts/dataTable/MyDataTable'
+import MySelect from '../../../components/parts/form/MySelect'
+import MyInput from '../../../components/parts/form/MyInput'
 export default {
-  name: 'ShowQuizSection',
+  name: 'IndexQuizTitles',
   components: {
-    MyInput,
+    MyDataTable,
     MySelect,
-    ErrorMessages
+    MyInput
   },
   mixins: [mixin],
   data: () => ({
-    loading: false,
     headers: [
       {
         text: "ID",
         align: "start",
-        value: "ID"
+        value: "ID",
+        sortable: false
       },
       {
         text: "Name",
-        value: "Name"
+        value: "Name",
+        sortable: false
       },
       {
         text: "Level",
-        value: "QuizLevel.Name"
+        value: "QuizLevelName",
+        sortable: false
       },
       {
         text: "CreatedAt",
-        value: "CreatedAt"
+        value: "CreatedAt",
+        sortable: false
       },
       { text: "UpdatedAt",
         value: "UpdatedAt",
+        sortable: false
       },
       {
-          text: 'Actions',
-          value: 'actions',
-          sortable: false
+        text: 'Actions',
+        value: 'actions',
+        sortable: false
       }
     ],
-    selectedItems: [],
-    dialog: false,
-    dialogDelete: false,
-    editedIndex: -1,
     editedItem: {
-      QuizLevelID: '',
-      QuizSectionID: '',
+      QuizLevelID: 0,
       Name: '',
-      Rate: 1
     },
     defaultItem: {
-      QuizSectionID: '',
+      QuizLevelID: 0,
       Name: '',
-      Rate: 1
     },
     quizLevels: [],
-    quizSections: [],
-    quizLevelRules: {
-      required: true
-    },
     nameRules: {
       max: 40,
       required: true
     },
-    errorMessages: []
-  }),
-  computed: {
-    formTitle () {
-      return this.editedIndex === -1 ? 'New' : 'Edit'
+    showSearchCondition: true,
+    defaultSearchConditions: {
+      page: 1,
+      selectedQuizLevelIDs: [],
+      keywords: '',
+      fromCreationDate: '',
+      toCreationDate: '',
+      fromUpdateDate: '',
+      toUpdateDate: '',
+      pageSize: 50,
+      ascending: false
     },
-    deleteBtn () {
-      return this.selectedItems.length
+    searchConditions: {
+      page: 1,
+      keywords: '',
+      selectedQuizLevelIDs: [],
+      fromCreationDate: '',
+      toCreationDate: '',
+      fromUpdateDate: '',
+      toUpdateDate: '',
+      pageSize: 50,
+      ascending: false
     }
-  },
-  watch: {
-    dialog (val) {
-      val || this.close()
-    },
-    dialogDelete (val) {
-      val || this.closeDelete()
-    },
-  },
-  mounted () {
-    this.fetchData()
-  },
+  }),
   methods: {
-    ...mapActions({ setFlashMessage: 'flashMessage/set' }),
-    fetchData: function () {
-      this.loading = true
-      this.$adminHttp.get('/admin/quiz_sections')
-      .then(response => {
-        if (response.data.ErrorMessages != null) {
-            console.log(response.data.ErrorMessages)
-            this.setFlashMessage({
-              type: 'warning',
-              message: 'Failed to fetch data ...'
-            })
-          } else {
-            this.quizLevels = response.data.QuizLevels
-            this.quizSections = response.data.QuizSections
-        }
-        this.loading = false
-      })
-      .catch((error) => {
-        console.log(error)
-      })
+    initQuizLevels (value) {
+      this.quizLevels = value
     },
-    editItem (item) {
-      this.editedIndex = this.quizSections.indexOf(item)
-      this.editedItem = Object.assign({}, item)
-      this.dialog = true
-    },
-    validation () {
-      return this.$refs.form.validate() ? true : false
-    },
-    close () {
-      this.dialog = false
-      this.$nextTick(() => {
-        this.editedItem = Object.assign({}, this.defaultItem)
-        this.editedIndex = -1
-        this.errorMessages = []
-      })
-    },
-    closeDelete () {
-      this.dialogDelete = false
-      this.$nextTick(() => {
-        this.editedItem = Object.assign({}, this.defaultItem)
-        this.editedIndex = -1
-      })
-    },
-    create () {
-      if (this.validation()) {
-        this.$adminHttp.post('/admin/quiz_sections', {
-          QuizLevelID: this.editedItem.QuizLevelID,
-          Name: this.editedItem.Name
-        })
-        .then(response => {
-          if (response.data.ErrorMessages != null) {
-            this.errorMessages = response.data.ErrorMessages
-          } else {
-            this.quizSections.push(response.data)
-            this.close()
-            this.setFlashMessage({
-              type: 'success', message: 'Created successfully'
-            })
-          }
-        })
-        .catch(error => {
-          console.log(error)
-          this.errorMessages = ['Something went wrong. Please try again']
-        })
-      }
-    },
-    update () {
-      if (this.validation()) {
-        this.$adminHttp.put(`/admin/quiz_sections/${this.editedItem.ID}`, {
-          QuizLevelID: this.editedItem.QuizLevelID,
-          Name: this.editedItem.Name,
-      })
-        .then(response => {
-          if (response.data.ErrorMessages != null) {
-            this.errorMessages = response.data.ErrorMessages
-          } else {
-            Object.assign(this.quizSections[this.editedIndex], response.data)
-            this.setFlashMessage({
-              type: 'success', message: 'Changes have been saved'
-            })
-            this.close()
-          }
-        })
-        .catch(error => {
-          console.log(error)
-          this.setFlashMessage({
-            type: 'error', message: 'Something went wrong. Please try again'
-          })
-        })
-      }
-    },
-    deleteItems () {
-      this.dialogDelete = true
-    },
-    deleteItemsConfirm () {
-      const selectedItemIds = this.selectedItems.map(item => item.ID)
-      this.$adminHttp.request({
-        method: 'delete',
-        url: "/admin/quiz_sections",
-        data: { deleteItemIds: selectedItemIds }
-      })
-        .then(response => {
-          if (response.data != null) {
-            console.log(response.data)
-            this.setFlashMessage({
-              type: 'warning', message: "Failed to delete ..."
-            })
-          } else {
-            this.quizSections = this.quizSections.filter( function (item) {
-              return selectedItemIds.includes(item.ID) === false
-            })
-          }
-          this.closeDelete()
-          this.setFlashMessage({
-            type: 'success', message: "Delete quiz sections successfully"
-          })
-        })
-        .catch(error => {
-          console.log(error)
-        })
+    updateEditedItem (value) {
+      this.editedItem = Object.assign({}, value)
     }
   }
 }


### PR DESCRIPTION
## チケットへのリンク

#23 

## やったこと

<!-- このプルリクで何をしたのか？ -->
quiz section　一覧ページに MyDataTable コンポーネントと MySearch コンポーネントを適応させた。

## やらないこと
無し
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## できるようになること（ユーザ目線）
1.条件検索
2.アイテムの複数一括削除
3.テーブルに表示させる最大データ数を変更させる
4.ページネーション
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## できなくなること（ユーザ目線）
無し
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認

<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
quiz section 一覧ページにて以下の動作確認を実行
1. search condition トグルボタンを押下
結果：条件検索欄の表示・非表示を確認

2. 条件検索欄に値を入力し、search ボタンを押下
結果：条件通りに データを取得できた

3. new ボタンを押下し、表示されたフォームに入力
結果：テーブルの一番上に作成したデータが表示された

4. テーブルに表示されたデータを選択し、 delete items ボタンを押下
結果：選択されたアイテムが表示されなくなった
また、リロードしても削除されたアイテムは表示されない。

5. テーブルに表示されたデータの更新ボタンを押下し、表示されたフォームに入力
結果：選択されたデータ内容が更新された

6. テーブルに表示されたデータの詳細ページリンクを押下
結果：選択したデータの詳細ページへ遷移した

## UI変更
#### 変更前のキャプチャ
![スクリーンショット 2021-08-30 7 08 45](https://user-images.githubusercontent.com/48712267/131267057-e8ef609a-225c-4d40-a5b9-875091ad332b.png)


#### 変更後のキャプチャ
![スクリーンショット 2021-08-30 7 09 02](https://user-images.githubusercontent.com/48712267/131267026-327418b4-a002-4857-8014-ea13678ba3d2.png)


#### 動きがある場合(GIF動画など)
![タイトルなし](https://user-images.githubusercontent.com/48712267/131267149-2fda2011-15b9-41d9-be5c-571d420c3d78.gif)


## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
