### PR TITLE
[update] close #25 quiz level 一覧ページに テーブル・条件検索コンポーネントを適応させる

### DIFF
--- a/src/components/parts/dataTable/MyDataTable.vue
+++ b/src/components/parts/dataTable/MyDataTable.vue
@@ -208,7 +208,7 @@ export default {
     linkName:                 { type: String, required: true },
     editedItem:               { type: Object, required: true },
     defaultItem:              { type: Object, required: true },
-    initQuizLevels:           { type: Function, required: true },
+    initQuizLevels:           { type: Function, default: () => 1 },
     updateEditedItem:         { type: Function, required: true }
   },
   data: () => ({
@@ -250,7 +250,13 @@ export default {
     viewingCount () {
       const from = ((this.page - 1) * this.pageSize) + 1
       const to = from + this.tableData.length - 1
-      return from + " - " + to 
+      if (from === to ) {
+        return from
+      } else if (to === 0) {
+        return 0
+      } else {
+        return from + " - " + to 
+      }
     },
     culculatePageCount() {
       return Math.ceil(this.itemsTotalCount / Number(this.pageSize))

--- a/src/views/admin/quiz-level/index.vue
+++ b/src/views/admin/quiz-level/index.vue
@@ -1,321 +1,101 @@
 <template>
-  <v-card>
-    <v-card-title>
-      Quiz Levels
-      <v-spacer></v-spacer>
-    </v-card-title>
-    <v-data-table
-      :headers="headers"
-      :items="quizLevels"
-      :sort-by="headers"
-      :loading="loading"
-      loading-text="Loading... Please wait"
-      item-key="ID"
-      show-select
-      v-model="selectedItems"
-    >
-      <template v-slot:top>
-        <v-toolbar flat>
-          <v-btn
-            small
-            color="error"
-            @click="deleteItems"
-            :disabled="!deleteBtn"
-          >
-            Delete Quiz Titles
-          </v-btn>
-          <v-spacer></v-spacer>
-          <v-dialog
-            v-model="dialog"
-            max-width="600px"
-          >
-          <template v-slot:activator="{ on, attrs }">
-            <v-btn
-              small
-              color="primary"
-              class="mb-2"
-              v-bind="attrs"
-              v-on="on"
-            >
-              New
-            </v-btn>
-          </template>
-          <v-card>
-            <v-card-title>
-              <span class="text-h5">{{ formTitle }}</span>
-            </v-card-title>
-
-            <v-card-text>
-              <v-container>
-                  <ErrorMessages :errorMessages=errorMessages></ErrorMessages>
-                  <v-form ref="form">
-                    <MyInput
-                      v-model="editedItem.Name"
-                      label="Name"
-                      v-bind="nameRules"
-                    />
-                  </v-form>
-              </v-container>
-            </v-card-text>
-
-            <v-card-actions>
-              <v-spacer></v-spacer>
-              <v-btn
-                color="blue darken-1"
-                text
-                @click="close"
-              >
-                Cancel
-              </v-btn>
-              <v-btn
-                v-if="editedIndex != -1"
-                color="blue darken-1"
-                text
-                @click="update"
-              >
-                Update
-              </v-btn>
-              <v-btn
-                v-if="editedIndex === -1"
-                color="blue darken-1"
-                text
-                @click="create"
-              >
-                Create
-              </v-btn>
-            </v-card-actions>
-          </v-card>
-          </v-dialog>
-          <v-dialog v-model="dialogDelete" max-width="500px">
-            <v-card>
-              <v-card-title class="text-h5">Are you sure you want to delete this item?</v-card-title>
-              <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn color="blue darken-1" text @click="closeDelete">Cancel</v-btn>
-                <v-btn color="blue darken-1" text @click="deleteItemsConfirm()">OK</v-btn>
-                <v-spacer></v-spacer>
-              </v-card-actions>
-            </v-card>
-          </v-dialog>
-        </v-toolbar>
-      </template>
-      <template v-slot:item.CreatedAt="{ item }" v-slot:activator="{ChangeFormat}">
-        {{ ChangeFormat(item.CreatedAt, 'yyyy/M/d H:m:s') }}
-      </template>
-      <template v-slot:item.UpdatedAt="{ item }" v-slot:activator="{ChangeFormat}">
-        {{ ChangeFormat(item.UpdatedAt, 'yyyy/M/d H:m:s') }}
-      </template> 
-      <template v-slot:item.actions="{ item }">
-        <router-link :to="{ name: 'ShowQuizLevel', params: { id: item.ID }}">
-          <v-icon
-            small
-            class="mr-2"
-          >
-            mdi-open-in-new
-          </v-icon>
-        </router-link>
-        <v-icon
-          small
-          class="mr-2"
-          color="primary"
-          @click="editItem(item)"
-        >
-          mdi-pencil
-        </v-icon>
-      </template>
-    </v-data-table>
-  </v-card>
+  <MyDataTable
+    title="Quiz Level"
+    v-model="searchConditions"
+    :defaultSearchConditions="defaultSearchConditions"
+    :headers="headers"
+    url="quiz_levels"
+    linkName="showQuizLevel"
+    :editedItem.sync="editedItem"
+    :defaultItem="defaultItem"
+    :initQuizLevels="initQuizLevels"
+    :updateEditedItem="updateEditedItem"
+  >
+    <template v-slot:form>
+      <MyInput
+        v-model="editedItem.Name"
+        label="Name"
+        v-bind="nameRules"
+      />
+    </template>
+  </MyDataTable>
 </template>
+
 <script>
-import { mapActions } from 'vuex'
-import MyInput from '../../../components/parts/form/MyInput'
-import ErrorMessages from '../../../components/parts/ErrorMessages'
 import mixin from '../../../mixins/globalMethods.js'
+import MyDataTable from '../../../components/parts/dataTable/MyDataTable'
+import MyInput from '../../../components/parts/form/MyInput'
 export default {
-  name: 'IndexQuizLevel',
+  name: 'IndexQuizTitles',
   components: {
-    MyInput,
-    ErrorMessages
+    MyDataTable,
+    MyInput
   },
   mixins: [mixin],
-  data () {
-    return {
-      loading: false,
-      headers: [
-        {
-          text: "ID",
-          align: "start",
-          value: "ID"
-        },
-        {
-          text: "Name",
-          value: "Name"
-        },
-        {
-          text: "CreatedAt",
-          value: "CreatedAt"
-        },
-        { text: "UpdatedAt",
-          value: "UpdatedAt",
-        },
-        {
-            text: 'Actions',
-            value: 'actions',
-            sortable: false
-        }
-      ],
-      selectedItems: [],
-      dialog: false,
-      dialogDelete: false,
-      editedIndex: -1,
-      editedItem: {
-        Name: ''
+  data: () => ({
+    headers: [
+      {
+        text: "ID",
+        align: "start",
+        value: "ID",
+        sortable: false
       },
-      defaultItem: {
-        Name: ''
+      {
+        text: "Name",
+        value: "Name",
+        sortable: false
       },
-      nameRules: {
-        max: 40,
-        required: true
+      {
+        text: "CreatedAt",
+        value: "CreatedAt",
+        sortable: false
       },
-      quizLevels: [],
-      errorMessages: []
+      { text: "UpdatedAt",
+        value: "UpdatedAt",
+        sortable: false
+      },
+      {
+        text: 'Actions',
+        value: 'actions',
+        sortable: false
+      }
+    ],
+    editedItem: {
+      Name: '',
+    },
+    defaultItem: {
+      Name: '',
+    },
+    nameRules: {
+      max: 40,
+      required: true
+    },
+    showSearchCondition: true,
+    defaultSearchConditions: {
+      page: 1,
+      keywords: '',
+      fromCreationDate: '',
+      toCreationDate: '',
+      fromUpdateDate: '',
+      toUpdateDate: '',
+      pageSize: 50,
+      ascending: false
+    },
+    searchConditions: {
+      page: 1,
+      keywords: '',
+      fromCreationDate: '',
+      toCreationDate: '',
+      fromUpdateDate: '',
+      toUpdateDate: '',
+      pageSize: 50,
+      ascending: false
     }
-  },
-  computed: {
-    formTitle () {
-      return this.editedIndex === -1 ? 'New' : 'Edit'
-    },
-    deleteBtn () {
-      return this.selectedItems.length
-    }
-  },
-  watch: {
-    dialog (val) {
-      val || this.close()
-    },
-    dialogDelete (val) {
-      val || this.closeDelete()
-    },
-  },
-  mounted () {
-    this.fetchData()
-  },
+  }),
   methods: {
-    ...mapActions({ setFlashMessage: 'flashMessage/set' }),
-    fetchData: function () {
-      this.loading = true
-      this.$adminHttp.get('/admin/quiz_levels')
-        .then((response) => {
-          if (response.data.ErrorMessages != null) {
-            console.log(response.data.ErrorMessages)
-            this.setFlashMessage({
-              type: 'error', message: 'Failed to get data ...'
-            })
-          } else {
-            this.quizLevels = response.data
-          }
-          this.loading = false
-        })
-        .catch(error => {
-          console.log(error)
-        })
-    },
-    editItem (item) {
-      this.editedIndex = this.quizLevels.indexOf(item)
-      this.editedItem = Object.assign({}, item)
-      this.dialog = true
-    },
-    close () {
-      this.dialog = false
-      this.$nextTick(() => {
-        this.editedItem = Object.assign({}, this.defaultItem)
-        this.editedIndex = -1
-        this.errorMessages = []
-      })
-    },
-    closeDelete () {
-      this.dialogDelete = false
-      this.$nextTick(() => {
-        this.editedItem = Object.assign({}, this.defaultItem)
-        this.editedIndex = -1
-      })
-    },
-    validation () {
-      return this.$refs.form.validate() ? true : false
-    },
-    create () {
-      if (this.validation()) {
-        this.$adminHttp.post('/admin/quiz_levels', {
-          Name: this.editedItem.Name,
-        })
-        .then(response => {
-          if (response.data.ErrorMessages != null) {
-            this.errorMessages = response.data.ErrorMessages
-          } else {
-            this.quizLevels.push(response.data)
-            this.setFlashMessage({
-              type: 'success', message: 'Created successfully'
-            })
-            this.close()
-          }
-        })
-        .catch(error => {
-          console.log(error)
-          this.errorMessages = ['Something went wrong. Please try again']
-        })
-      }
-    },
-    update () {
-      if (this.validation()) {
-        this.$adminHttp.put(`/admin/quiz_levels/${this.editedItem.ID}`, {
-          Name: this.editedItem.Name,
-      })
-        .then(response => {
-          if (response.data.ErrorMessages != null) {
-            this.errorMessages = response.data.ErrorMessages
-          } else {
-            Object.assign(this.quizLevels[this.editedIndex], this.editedItem)
-            this.setFlashMessage({
-              type: 'success', message: 'Changes have been saved'
-            })
-            this.close()
-          }
-        })
-        .catch(error => {
-          console.log(error)
-          this.errorMessages = ['Something went wrong. Please try again']
-        })
-      }
-    },
-    deleteItems () {
-      this.dialogDelete = true
-    },
-    deleteItemsConfirm () {
-      const selectedQuizLevelIds = this.selectedItems.map(item => item.ID)
-      this.$adminHttp.request({
-        method: 'delete',
-        url: "/admin/quiz_levels",
-        data: { DeleteItemIds: selectedQuizLevelIds }
-      })
-        .then(response => {
-          if (response.data != null) {
-            console.log(response.data)
-            this.setFlashMessage({ type: 'warning', message: "Failed to delete ..."})
-          } else {
-          this.quizLevels = this.quizLevels.filter( function (item) {
-            return selectedQuizLevelIds.includes(item.ID) === false
-          })
-          }
-          this.closeDelete()
-          this.setFlashMessage({
-            type: 'success', message: "Delete successfully"
-          })
-        })
-        .catch(error => {
-          console.log(error)
-        })
-    }
+    updateEditedItem (value) {
+      this.editedItem = Object.assign({}, value)
+    }    
   }
 }
 </script>


### PR DESCRIPTION
## チケットへのリンク

#25 
<!-- #12 -->

## やったこと
quiz level 一覧ページに MyDataTable コンポーネントを適応させた

<!-- このプルリクで何をしたのか？ -->

## やらないこと
無し
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## できるようになること（ユーザ目線）
1. 条件検索
2. ページネーション
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## できなくなること（ユーザ目線）
無し
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認

<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

## UI変更

#### 変更後のキャプチャ
![スクリーンショット 2021-08-31 15 33 31](https://user-images.githubusercontent.com/48712267/131453607-5ede0b5a-7261-474f-9f3d-b3389a1fcda4.png)

#### 動きがある場合(GIF動画など)
![quiz level index page](https://user-images.githubusercontent.com/48712267/131454093-3bf96087-1f17-4598-b424-0a2be00aa3fd.gif)

## その他
無し

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
