### PR TITLE
Develop

### DIFF
--- a/src/components/parts/showPage/ShowProperty.vue
+++ b/src/components/parts/showPage/ShowProperty.vue
@@ -1,0 +1,129 @@
+<template>
+  <div>
+    <p>
+      <v-icon>mdi-clock-check-outline</v-icon>
+      {{ ChangeFormat(item.CreatedAt, 'yyyy/MM/dd HH:mm') }}
+      <v-icon>mdi-cached</v-icon>
+      {{ ChangeFormat(item.UpdatedAt, 'yyyy/MM/dd HH:mm') }}
+    </p>
+    <p>ID: {{ item.ID }}</p>
+    <ErrorMessages v-model="this.errorMessages" />
+    <v-form ref="form" v-model="valid" style="max-width: 600px;">
+      <slot name="form"></slot>
+      <div
+        class="my-4"
+        align="center"
+      >
+        <v-btn
+          small
+          class="mr-5"
+          color="primary"
+          :disabled="!postable"
+          @click="update"
+        >
+          Update
+        </v-btn>
+        <v-btn
+          small
+          color="error"
+          @click="deleteItem"
+        >
+        Delete
+        </v-btn>
+      </div>
+    </v-form>
+  </div>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+import ErrorMessages from '../ErrorMessages'
+export default {
+  name: 'ShowProperty',
+  components: {
+    ErrorMessages
+  },
+  props: {
+    value: { type: Object, required: true },
+    formKeys: { type: Array, required: true },
+    url: { type: String, required: true }
+  },
+  data: () => ({
+    valid: true,
+    errorMessages: [],
+    itemBeforeEdit: null
+  }),
+  computed: {
+    item: {
+      get() {
+        return this.value
+      },
+      set(value) {
+        this.$emit("input", value)
+      }
+    },
+    defaultUrl () {
+      return "/admin/" + this.url
+    },
+    formValues () {
+      var formValues = {}
+      this.formKeys.forEach(key => {
+        formValues[key] = this.item[key]
+      })
+      return formValues
+    },
+    postable () {
+      return this.IsFormValuesChanged(this.itemBeforeEdit, this.item, this.formKeys) && this.validation()
+    }
+  },
+  created () {
+    this.itemBeforeEdit = {...this.item}
+  },
+  methods: {
+    ...mapActions({ setFlashMessage: 'flashMessage/set' }),
+    validation () {
+      return this.$refs.form.validate() ? true : false
+    },
+    update () {
+      if (this.validation()) {
+        this.$adminHttp.put(this.defaultUrl + "/" + this.$route.params.id, this.formValues)
+        .then(response => {
+          if (response.data.ErrorMessages != null) {
+            this.errorMessages = response.data.ErrorMessages
+          } else {
+            this.itemBeforeEdit = response.data
+            this.setFlashMessage({
+              type: 'success', message: 'Changes have been saved'
+            })
+          }
+        })
+      }
+    },
+    deleteItem () {
+      if (window.confirm("Are you sure you want to delete this item ?")) {
+        this.$adminHttp.delete(this.defaultUrl)
+        .then(response => {
+          if (response.data != null) {
+            console.log(response.data)
+            this.setFlashMessage({
+              type: 'warning', message: 'Failed to delete item'
+            })
+          } else {
+            this.setFlashMessage({
+              type: 'success', message: 'delte itemsuccessfully'
+            })
+            this.$router.push(this.defaultUrl)
+          }
+        })
+      }
+    }
+
+  }
+}
+</script>
+
+<style scoped>
+.v-icon {
+  padding-bottom: 5px;
+}
+</style>

--- a/src/components/parts/showPage/ShowProperty.vue
+++ b/src/components/parts/showPage/ShowProperty.vue
@@ -101,7 +101,11 @@ export default {
     },
     deleteItem () {
       if (window.confirm("Are you sure you want to delete this item ?")) {
-        this.$adminHttp.delete(this.defaultUrl)
+        this.$adminHttp.request({
+          method: 'delete',
+          url: this.defaultUrl,
+          data: { DeleteItemIds: [ this.item.ID ] }
+        })
         .then(response => {
           if (response.data != null) {
             console.log(response.data)


### PR DESCRIPTION
## チケットへのリンク

#7 

## やったこと
詳細データを表示・編集・削除できる共通コンポーネントと付随する quiz section を表示・検索するデータテーブルコンポーネントを適応させた。

1. ShowProperty
2. MyDataTable

<!-- このプルリクで何をしたのか？ -->

## できるようになること（ユーザ目線）
1. quiz level の詳細表示
2. 紐ずく quiz section の表示、作成、編集

<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認
1. /admin/quiz_levels/1 に遷移
 結果：該当の quiz level の詳細情報が表示された

2. name の値を変更して、update ボタンを押下
結果：値の更新がデータベースに反映されたことを確認

3. "show item belongs to quiz level" ボタンを押下
結果：quiz level に紐ずく quiz section を表示するテーブルが表示されたことを確認

4. quiz section テーブルで条件検索
結果：表示しているページの quiz level に紐づいた quiz section の中から条件に合うものだけが表示されたことを確認
 5. new ボタンを押下し、quiz level に紐ずく quiz section を新規作成
結果：作成した quiz section がデータベースに反映され、テーブルに表示されたことを確認

6. quiz level に紐ずく quiz section の 編集ボタンを押下し、値を変えて更新
結果：更新内容がデータベースに反映され、テーブルにある該当の quiz section の値が更新された値に変更されていることを確認

7. quiz level の delete ボタンを押下
結果：該当の quiz level がデータベースから削除され、 quiz level 一覧ページに繊維されたことを確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

## UI変更
#### 動きがある場合(GIF動画など)
![quiz level 詳細ページ](https://user-images.githubusercontent.com/48712267/133087697-b49a9b5f-1012-43fb-ac2b-97c595bbd0b6.gif)

## その他
なし
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
