### PR TITLE
Develop

### DIFF
--- a/src/components/parts/dataTable/MyDataTable.vue
+++ b/src/components/parts/dataTable/MyDataTable.vue
@@ -22,9 +22,10 @@
         :defaultSearchConditions="defaultSearchConditions"
         :quizLevels="quizLevels"
         :url="defaultPath"
+        :searchAction="searchAction"
         v-if="showSearchCondition"
       >
-        <template v-slot:selectCategory>
+        <template v-slot:searchForm>
           <slot name="search"></slot>
         </template>
       </MySearch>
@@ -34,9 +35,11 @@
         :loading="loading"
         loading-text="Loading... Please wait"
         item-key="ID"
+        :items-per-page="searchConditions.pageSize"
         show-select
         v-model="selectedItems"
         hide-default-footer
+        class="mytable"
       >
         <template v-slot:top>
           <v-toolbar flat class="mb-4">
@@ -52,9 +55,6 @@
                   v-on="on"
                   class="mr-4"
                 >
-                  <v-icon left>
-                    mdi-plus
-                  </v-icon>
                   New
                 </v-btn>
               </template>
@@ -66,7 +66,7 @@
                   <v-container>
                     <ErrorMessages :errorMessages=errorMessages></ErrorMessages>
                     <v-form ref="form">
-                      <slot name="form"></slot>
+                      <slot name="form" v-bind:editedIndex="editedIndex" ></slot>
                     </v-form>
                   </v-container>
                 </v-card-text>
@@ -165,13 +165,16 @@
         </template>
         <template v-slot:footer v-if="showBottomDeleteBtn">
           <v-btn
-              x-small
-              color="error"
-              class="ml-4"
-              @click="deleteItems"
-              :disabled="!deleteBtn"
-            >
-              Delete {{ title }}
+            small
+            color="error"
+            class="ml-4"
+            @click="deleteItems"
+            :disabled="!deleteBtn"
+          >
+            <v-icon left>
+              mdi-trash-can-outline
+            </v-icon>
+            Delete {{ title }}
           </v-btn>
         </template>
       </v-data-table>
@@ -209,7 +212,8 @@ export default {
     editedItem:               { type: Object, required: true },
     defaultItem:              { type: Object, required: true },
     initQuizLevels:           { type: Function, default: () => 1 },
-    updateEditedItem:         { type: Function, required: true }
+    updateEditedItem:         { type: Function, required: true },
+    searchAction:             { type: Function }
   },
   data: () => ({
     tableData: [],
@@ -320,6 +324,7 @@ export default {
         this.editedIndex = -1
         this.errorMessages = []
       })
+      this.$refs.form.reset()
     },
     closeDelete () {
       this.dialogDelete = false
@@ -386,7 +391,7 @@ export default {
       this.$adminHttp.request({
         method: 'delete',
         url: deleteUrl,
-        data: { DeleteItemIds: selectedItemIds }
+        data: { SelectedItemIds: selectedItemIds }
       })
       .then(response => {
         if (response.data != null) {
@@ -414,8 +419,18 @@ export default {
       })
     },
     pageTransition (item) {
-      this.$router.push(this.url + "/" + item.ID)
+      this.$router.push("/" + this.defaultPath + "/" + item.ID)
     }
   }
 }
 </script>
+
+<style>
+.mytable .text-start, .v-application--is-ltr .mytable .v-data-table__mobile-row__cell{
+  max-width: 180px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+</style>

--- a/src/components/parts/form/MyQuizForm.vue
+++ b/src/components/parts/form/MyQuizForm.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <MyTextarea
+      v-model="quiz.Question"
+      label="Question"
+      v-bind="questionRules"
+    />
+    <MyInput
+      v-model="quiz.Answer"
+      label="Answer"
+      v-bind="choiceRules"
+    />
+    <MyInput
+      v-model="quiz.Choice1"
+      label="Choice1"
+      v-bind="choiceRules"
+    />
+    <MyInput
+      v-model="quiz.Choice2"
+      label="Choice2"
+      v-bind="choiceRules"
+    />
+    <MyInput
+      v-model="quiz.Choice3"
+      label="Choice3"
+      v-bind="choiceRules"
+    />
+  </div>
+</template>
+
+<script>
+import MyTextarea from '@/components/parts/form/MyTextarea'
+import MyInput from '@/components/parts/form/MyInput'
+export default {
+  name: "MyQuizForm",
+  components: {
+    MyTextarea,
+    MyInput
+  },
+  props: {
+    value: { type: Object, required: true }
+  },
+  data: () => ({
+    questionRules: {
+      max: 300,
+      required: true
+    },
+    choiceRules: {
+      max: 150,
+      required: true
+    },
+  }),
+  computed: {
+    quiz: {
+      get () {
+        return this.value
+      },
+      set (value) {
+        this.$emit("input", value)
+      }
+    }
+  }
+}
+</script>

--- a/src/views/admin/quiz/index.vue
+++ b/src/views/admin/quiz/index.vue
@@ -1,55 +1,296 @@
 <template>
-  <div>
-    <h1>Quiz 一覧</h1>
-    <p><router-link to='/admin/quizzes/new'>新規作成</router-link></p>
-    <div v-for='(quiz, index) in quizzes' :key="index">
-      <ul>
-        <li>{{quiz.Question}}</li>
-        <li>{{quiz.Answer}}</li>
-        <li>{{quiz.Choice1}}</li>
-        <li>{{quiz.Choice2}}</li>
-        <li>{{quiz.CHoice3}}</li>
-        <li>
-          <router-link :to="{ name: 'EditQuiz', params: { id: quiz.ID}}">編集</router-link>
-          <button v-on:click="deleteQuiz(quiz.ID, index)">削除</button>
-        </li>
-      </ul>
-    </div>
-  </div>
+  <MyDataTable
+    title="Quiz"
+    v-model="searchConditions"
+    :defaultSearchConditions="defaultSearchConditions"
+    :headers="headers"
+    url="quizzes"
+    linkName="showQuiz"
+    :editedItem.sync="editedItem"
+    :defaultItem="defaultItem"
+    :initQuizLevels="initQuizLevels"
+    :updateEditedItem="updateEditedItem"
+  >
+    <template v-slot:search>
+      <MySelect
+        v-model="searchConditions.selectedQuizLevelIDs"
+        label="Quiz Level"
+        :items="quizLevels"
+        itemText="Name"
+        itemValue="ID"
+        multiple
+        chips
+        clearable
+        @change="SetCategoryOptionsForSelect(
+          'admin/quiz_sections/get_by_quiz_level_ids',
+          'quizSectionOptionsForSearch',
+          searchConditions.selectedQuizLevelIDs
+        )"
+      />
+      <MySelect
+        v-model="searchConditions.selectedQuizSectionIDs"
+        label="Quiz Section"
+        :items="quizSectionOptionsForSearch"
+        itemText="Name"
+        itemValue="ID"
+        multiple
+        chips
+        clearable
+        @change="SetCategoryOptionsForSelect(
+          'admin/quiz_titles/get_by_quiz_section_ids',
+          'quizTitleOptionsForSearch',
+          searchConditions.selectedQuizSectionIDs
+        )"
+      />
+      <MySelect
+        v-model="searchConditions.selectedQuizTitleIDs"
+        label="Quiz Title"
+        :items="quizTitleOptionsForSearch"
+        itemText="Name"
+        itemValue="ID"
+        multiple
+        chips
+        clearable
+        />
+    </template>
+    <template v-slot:form>
+      <MySelect
+        v-model="editedItem.QuizLevelID"
+        label="Quiz Level"
+        :items="quizLevels"
+        itemText="Name"
+        itemValue="ID"
+        @change="SetCategoryOptionsForSelect(
+          'admin/quiz_sections/get_by_quiz_level_ids',
+          'quizSectionOptionsForForm',
+          editedItem.QuizLevelID
+        )"
+      />
+      <MySelect
+        v-model="editedItem.QuizSectionID"
+        label="Quiz Section"
+        :items="quizSectionOptionsForForm"
+        itemText="Name"
+        itemValue="ID"
+        required
+        @focus="SetCategoryOptionsForSelect(
+          'admin/quiz_sections/get_by_quiz_level_ids',
+          'quizSectionOptionsForForm',
+          editedItem.QuizLevelID
+        )"
+      />
+      <MySelect
+        v-model="editedItem.QuizTitleID"
+        label="Quiz Title"
+        :items="quizTitleOptionsForForm"
+        itemText="Name"
+        itemValue="ID"
+        required
+        @focus="SetCategoryOptionsForSelect(
+          'admin/quiz_titles/get_by_quiz_section_ids',
+          'quizTitleOptionsForForm',
+          editedItem.QuizSectionID
+        )"
+      />
+      <MyTextarea
+        v-model="editedItem.Question"
+        label="Question"
+        v-bind="questionRules"
+      />
+      <MyInput
+        v-model="editedItem.Answer"
+        label="Answer"
+        v-bind="choiceRules"
+      />
+      <MyInput
+        v-model="editedItem.Choice1"
+        label="Choice1"
+        v-bind="choiceRules"
+      />
+      <MyInput
+        v-model="editedItem.Choice2"
+        label="Choice2"
+        v-bind="choiceRules"
+      />
+      <MyInput
+        v-model="editedItem.Choice3"
+        label="Choice3"
+        v-bind="choiceRules"
+      />
+    </template>
+  </MyDataTable>
 </template>
 
 <script>
+import mixin from '../../../mixins/globalMethods.js'
+import MyDataTable from '../../../components/parts/dataTable/MyDataTable'
+import MySelect from '../../../components/parts/form/MySelect'
+import MyInput from '../../../components/parts/form/MyInput'
+import MyTextarea from '../../../components/parts/form/MyTextarea'
 export default {
-  name: 'quizzesIndex',
-  data: function () {
-    return {
-      quizzes: null
+  name: 'IndexQuizTitles',
+  components: {
+    MyDataTable,
+    MySelect,
+    MyInput,
+    MyTextarea
+  },
+  mixins: [mixin],
+  data: () => ({
+    headers: [
+      {
+        text: "ID",
+        align: "start",
+        value: "ID",
+        sortable: false
+      },
+      {
+        text: "Question",
+        value: "Question",
+        sortable: false,
+        cellClass: ""
+      },
+      {
+        text: "Answer",
+        value: "Answer",
+        sortable: false
+      },
+      {
+        text: "Choice1",
+        value: "Choice1",
+        sortable: false
+      },
+      {
+        text: "Choice2",
+        value: "Choice2",
+        sortable: false
+      },
+      {
+        text: "Choice3",
+        value: "Choice3",
+        sortable: false
+      },
+      {
+        text: "CreatedAt",
+        value: "CreatedAt",
+        sortable: false
+      },
+      { text: "UpdatedAt",
+        value: "UpdatedAt",
+        sortable: false
+      },
+      {
+        text: 'Actions',
+        value: 'actions',
+        sortable: false
+      }
+    ],
+    editedItem: {
+      QuizLevelID: 0,
+      QuizSectionID: 0,
+      QuizTitleID: 0,
+      Question: "",
+      Answer: "",
+      Choice1: "",
+      Choice2: "",
+      Choice3: ""
+    },
+    defaultItem: {
+      QuizLevelID: 0,
+      QuizSectionID: 0,
+      QuizTitleID: 0,
+      Question: "",
+      Answer: "",
+      Choice1: "",
+      Choice2: "",
+      Choice3: ""
+    },
+    quizLevels: [],
+    quizSectionOptionsForForm: [],
+    quizTitleOptionsForForm: [],
+    questionRules: {
+      max: 300,
+      required: true
+    },
+    choiceRules: {
+      max: 150,
+      required: true
+    },
+    rateArray: [...Array(41)].map((_, i) => Math.round(((i * 0.1) + 1) * 10) / 10),
+    showSearchCondition: true,
+    quizSectionOptionsForSearch: [],
+    quizTitleOptionsForSearch: [],
+    defaultSearchConditions: {
+      page: 1,
+      selectedQuizLevelIDs: [],
+      selectedQuizSectionIDs: [],
+      selectedQuizTitleIDs: [],
+      keywords: '',
+      fromCreationDate: '',
+      toCreationDate: '',
+      fromUpdateDate: '',
+      toUpdateDate: '',
+      pageSize: 50,
+      ascending: false
+    },
+    searchConditions: {
+      page: 1,
+      keywords: '',
+      selectedQuizLevelIDs: [],
+      selectedQuizSectionIDs: [],
+      selectedQuizTitleIDs: [],
+      fromCreationDate: '',
+      toCreationDate: '',
+      fromUpdateDate: '',
+      toUpdateDate: '',
+      pageSize: 50,
+      ascending: false
+    }
+  }),
+  watch: {
+    'searchConditions.selectedQuizLevelIDs': function (val) {
+      if (val.length === 0) {
+        this.searchConditions.selectedQuizSectionIDs = []
+        this.searchConditions.selectedQuizTitleIDs = []
+      }
+    },
+    'searchConditions.selectedQuizSectionIDs': function (val) {
+      if (val.length === 0) {
+        this.searchConditions.selectedQuizTitleIDs = []
+      }
+    },
+    'editedItem.QuizLevelID': function (val) {
+      if (val.length === 0 ) {
+        this.editedItem.QuizSectionID = 0
+        this.editedItem.QuizTitleID = 0
+      }
+    },
+    'editedItem.QuizSectionID': function (val) {
+      if (val.length === 0 ) {
+        this.editedItem.QuizTitleID = 0
+      }
     }
   },
-  created: function () {
-    this.fetchData()
-  },
   methods: {
-    fetchData: function () {
-      this.$adminHttp.get('/admin/quizzes')
-        .then((response) => {
-          this.quizzes = response.data.Quizzes
-        })
-        .catch((error) => {
-          this.$router.push({ path: '/admin/home' })
-          console.log(error)
-        })
+    initQuizLevels (value) {
+      this.quizLevels = value
     },
-    deleteQuiz: function (quizID, index) {
-      this.$adminHttp.delete(`/admin/quizzes/${quizID}`)
-        .then(response => {
-          if (response.data != null) {
-            this.errorMessages = response.data.ErrorMessages
-            alert(response.data)
-            alert("failed to delete quiz")
-          }
-          this.quizzes.splice(index)
-        })
+    updateEditedItem (value) {
+      this.editedItem = Object.assign({}, value)
+      if (this.editedItem.Name != "") {
+        this.SetCategoryOptionsForSelect(
+          'admin/quiz_sections/get_by_quiz_level_ids',
+          'quizSectionOptionsForForm',
+          value.QuizLevelID
+        )
+      }
+      if (this.editedItem.Name != "") {
+        this.SetCategoryOptionsForSelect(
+          'admin/quiz_sections/get_by_quiz_section_ids',
+          'quizSectionOptionsForForm',
+          value.QuizSectionID
+        )
+      }
     }
   }
 }

--- a/src/views/admin/quiz/index.vue
+++ b/src/views/admin/quiz/index.vue
@@ -53,45 +53,47 @@
         clearable
         />
     </template>
-    <template v-slot:form>
-      <MySelect
-        v-model="editedItem.QuizLevelID"
-        label="Quiz Level"
-        :items="quizLevels"
-        itemText="Name"
-        itemValue="ID"
-        @change="SetCategoryOptionsForSelect(
-          'admin/quiz_sections/get_by_quiz_level_ids',
-          'quizSectionOptionsForForm',
-          editedItem.QuizLevelID
-        )"
-      />
-      <MySelect
-        v-model="editedItem.QuizSectionID"
-        label="Quiz Section"
-        :items="quizSectionOptionsForForm"
-        itemText="Name"
-        itemValue="ID"
-        required
-        @focus="SetCategoryOptionsForSelect(
-          'admin/quiz_sections/get_by_quiz_level_ids',
-          'quizSectionOptionsForForm',
-          editedItem.QuizLevelID
-        )"
-      />
-      <MySelect
-        v-model="editedItem.QuizTitleID"
-        label="Quiz Title"
-        :items="quizTitleOptionsForForm"
-        itemText="Name"
-        itemValue="ID"
-        required
-        @focus="SetCategoryOptionsForSelect(
-          'admin/quiz_titles/get_by_quiz_section_ids',
-          'quizTitleOptionsForForm',
-          editedItem.QuizSectionID
-        )"
-      />
+    <template v-slot:form="slotProps">
+      <div v-if="slotProps.editedIndex === -1">
+        <MySelect
+          v-model="editedItem.QuizLevelID"
+          label="Quiz Level"
+          :items="quizLevels"
+          itemText="Name"
+          itemValue="ID"
+          @change="SetCategoryOptionsForSelect(
+            'admin/quiz_sections/get_by_quiz_level_ids',
+            'quizSectionOptionsForForm',
+            editedItem.QuizLevelID
+          )"
+        />
+        <MySelect
+          v-model="editedItem.QuizSectionID"
+          label="Quiz Section"
+          :items="quizSectionOptionsForForm"
+          itemText="Name"
+          itemValue="ID"
+          required
+          @focus="SetCategoryOptionsForSelect(
+            'admin/quiz_sections/get_by_quiz_level_ids',
+            'quizSectionOptionsForForm',
+            editedItem.QuizLevelID
+          )"
+        />
+        <MySelect
+          v-model="editedItem.QuizTitleID"
+          label="Quiz Title"
+          :items="quizTitleOptionsForForm"
+          itemText="Name"
+          itemValue="ID"
+          required
+          @focus="SetCategoryOptionsForSelect(
+            'admin/quiz_titles/get_by_quiz_section_ids',
+            'quizTitleOptionsForForm',
+            editedItem.QuizSectionID
+          )"
+        />
+      </div>
       <MyTextarea
         v-model="editedItem.Question"
         label="Question"


### PR DESCRIPTION
## チケットへのリンク

#35 

## やったこと

<!-- このプルリクで何をしたのか？ -->
quiz 一覧ページに以下のコンポーネントを適応させ、コードを簡素化した。

1. MyDataTable
2. ShowProperty

quiz 新規作成時は quiz level などのカテゴリー選択欄を表示させ、編集時はカテゴリー選択欄は表示させないようにした。

## やらないこと
quiz は複数の quiz title に紐付くので、編集フォームで複数の紐づく quiz title の追加・解除は、実装が複雑すぎるので、やらないことにした。
quiz に紐づく quiz title の追加や解除は、quiz 詳細ページで実装することにした。

<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
なし

## できるようになること（ユーザ目線）
なし
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## できなくなること（ユーザ目線）
なし
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認
1. quiz 一覧テーブルにデータが表示されるか
結果： 初期データが正確に表示されていた
2. quiz の新規作成ができるか
結果：new ボタン押下から表示されたフォームに入力すると、quiz を新規作成できた
3. quiz の編集ができるか
結果：該当 quiz がある行の右端にある編集ボタンを押下し、フォームの初期値を変更すると、quiz を更新できた
4. quiz の削除ができるか
結果：該当 quiz の行にある左端のチェックボタンを押下し、有効となった delete ボタンを押下すると、quiz を削除できた
5. quiz の条件検索ができるか
結果：各カテゴリーを選択すると、そのカテゴリーにのみ紐づく quiz が表示される
6. quiz 詳細ページへの遷移ができるか
結果：該当の quiz の行にある右端の遷移ボタンを押下すると、その quiz の詳細ページに遷移した。
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

## UI変更
#### 動きがある場合(GIF動画など)
![quiz 一覧ページ](https://user-images.githubusercontent.com/48712267/133909387-cf8a76bd-67e7-40dc-b6bf-98fa6fdd44bf.gif)

## その他
なし
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->