### PR TITLE
[add] close #34 quiz title 詳細画面にて、 quiz title に紐付いた quiz を解除する機能を追加

### DIFF
--- a/src/components/parts/dataTable/MyDataTable.vue
+++ b/src/components/parts/dataTable/MyDataTable.vue
@@ -110,6 +110,7 @@
               </v-icon>
               Delete items
             </v-btn>
+            <slot name="btn" v-bind:selectedItems="selectedItems"></slot>
             <v-spacer></v-spacer>
             <span class="d-none d-sm-flex mr-3 text-caption grey--text text--darken-3">
               viewing {{ viewingCount }} of {{ itemsTotalCount }} results
@@ -337,6 +338,14 @@ export default {
         this.$router.push({ query: query })
       }
     },
+    refleshTableData () {
+      const selectedItemIds = this.selectedItems.map(item => item.ID)
+      this.tableData = this.tableData.filter( function (item) {
+        return selectedItemIds.includes(item.ID) === false
+      })
+      this.itemsTotalCount -= this.selectedItems.length
+      this.selectedItems = []
+    },
     validation () {
       return this.$refs.form.validate() ? true : false
     },
@@ -397,26 +406,21 @@ export default {
         if (response.data != null) {
           console.log(response.data)
           this.setFlashMessage({
-            type: 'warning', message: 'Failed to delete quizzes'
+            type: 'warning', message: 'Failed to delete items'
           })
         } else {
-          this.tableData = this.tableData.filter( function (item) {
-            return selectedItemIds.includes(item.ID) === false
-          })
-          this.itemsTotalCount -= this.selectedItems.length
-          this.selectedItems = []
+          this.reflashTableData()
           this.setFlashMessage({
-            type: 'success', message: 'Remove quizzes successfully'
+            type: 'success', message: 'Delete items successfully'
           })
         }
         this.closeDelete()
       })
-      .catch((error) => {
-        console.log(error)
+      .catch(
         this.setFlashMessage({
-          type: 'warning', message: 'Failed to delete quizzes'
+          type: 'warning', message: 'Failed to delete items'
         })
-      })
+      )
     },
     pageTransition (item) {
       this.$router.push("/" + this.defaultPath + "/" + item.ID)

--- a/src/views/admin/quiz-title/show.vue
+++ b/src/views/admin/quiz-title/show.vue
@@ -70,6 +70,7 @@
     <v-card v-if="showTable">
       <MyDataTable
         v-if="showTable"
+        ref="dataTable"
         :title="tableTitle"
         v-model="searchConditions"
         :defaultSearchConditions="defaultSearchConditions"
@@ -80,6 +81,17 @@
         :defaultItem="defaultItem"
         :updateEditedItem="updateEditedItem"
       >
+        <template v-slot:btn="slotProps">
+          <v-btn
+            small
+            outlined
+            color="error"
+            :disabled="!slotProps.selectedItems.length"
+            @click="removeQuizzes(slotProps.selectedItems)"
+          >
+            remove quizzes
+          </v-btn>
+        </template>
         <template v-slot:form>
           <MyTextarea
             v-model="editedItem.Question"
@@ -290,6 +302,27 @@ export default {
     },
     validation () {
       return this.$refs.form.validate() ? true : false
+    },
+    removeQuizzes(selectedItems) {
+      const selectedItemIds = selectedItems.map(item => item.ID)
+      this.$adminHttp.request({
+        method: 'delete',
+        url: `/admin/quiz_titles/${this.$route.params.id}/remove_quizzes`,
+        data: { SelectedItemIds: selectedItemIds }
+      })
+      .then(response => {
+        if (response.data != null) {
+          console.log(response.data)
+          this.setFlashMessage({
+            type: 'warning', message: 'Failed to delete items'
+          })
+        } else {
+          this.$refs.dataTable.refleshTableData()
+          this.setFlashMessage({
+            type: 'success', message: 'Remove quizzes successfully'
+          })          
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
## チケットへのリンク

#34 

## やったこと
quiz title 詳細画面の quiz title 一覧テーブルに remove quizzes ボタンを追加。
remove quizzes ボタンは quiz のチェックボックスを選択すると有効化するようにした。
このボタンを押すと、以下の ajax 通信をする
 url: "/admin/quiz_titles/:id/remove_quizzes" 
request body: [number](選択した quiz の id 配列)
<!-- このプルリクで何をしたのか？ -->

## やらないこと
 なし
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## できるようになること（ユーザ目線）
quiz が他の quiz title に紐付いていた場合、他の quiz title に影響することなく、quiz title と quiz の紐付きを解除できる。
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## できなくなること（ユーザ目線）
なし
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認
quiz title 詳細画面にて、quiz title に紐付いた quiz 一覧テーブルの適当な quiz のチェックボックスを押下。
有効となった remove quizzes ボタンを押下。
結果：
1. quiz title 詳細画面にある quiz 一覧テーブルから選択した quiz が削除されたことを確認。
2. quiz 一覧画面にて、 quiz 自体が削除されていないことを確認。

<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

## UI変更
#### 動きがある場合(GIF動画など)
![remove quizzes](https://user-images.githubusercontent.com/48712267/134067071-6da3a09d-0086-4cd3-b8b0-f24440a2a137.gif)

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
