### PR TITLE
Develop

### DIFF
--- a/src/components/globals/FlashMessage.vue
+++ b/src/components/globals/FlashMessage.vue
@@ -37,7 +37,7 @@ export default {
 <style scoped>
 .flash_message {
   position: fixed;
-  z-index: 10;
+  z-index: 100000;
   top: 30px;
   right: 10px;
 }

--- a/src/components/parts/search/MySearch.vue
+++ b/src/components/parts/search/MySearch.vue
@@ -19,7 +19,7 @@
       label="Keyword"
     />
     <div style="max-width: 600px;">
-      <slot name="selectCategory"></slot>
+      <slot name="searchForm"></slot>
     </div>
     <v-row class="mt-0 mb-3">
       <v-col cols="12" sm="6">
@@ -71,11 +71,8 @@
       <v-btn
         color="primary"
         small
-        @click="Search(searchConditions, searchUrl, 1)"
+        @click="action(searchConditions, 1)"
       >
-        <v-icon left>
-          mdi-magnify
-        </v-icon>
         Search
       </v-btn>
     </v-card-actions>
@@ -102,10 +99,9 @@ export default {
       type: Object,
       required: true
     },
-    url: {
-      type: String,
-      required: true
-    },
+    searchFunc: {
+      type: Function
+    }
   },
   computed: {
     searchConditions: {
@@ -115,16 +111,17 @@ export default {
       set(value) {
         this.$emit("input", value)
       }
-    },
-    searchUrl () {
-      return this.url + "/search"
     }
   },
   methods: {
-    Search (searchConditions, url, page) {
+    action (searchConditions, page) {
       searchConditions.page = page
       searchConditions = this.RemoveEmptyValue(searchConditions)
-      this.$router.push({ query: searchConditions })
+      if (this.searchFunc) {
+        this.searchFunc(searchConditions)
+      } else {
+        this.$router.push({ query: searchConditions })
+      }
     },
     ClearSearchConditions() {
       if (window.confirm("Are you sure you wnat to clear 'All' search conditions")) {

--- a/src/mixins/globalMethods.js
+++ b/src/mixins/globalMethods.js
@@ -52,25 +52,21 @@ export default {
       .then(response => response.data)
     },
     SetCategoryOptionsForSelect (url, targetOptions, IDs) {
-      if (IDs.length === 0) {
+      if (!this.HasAnyValue(IDs)) {
         this[targetOptions] = []
-        return
+      } else {
+        this.GetCategoryOptions(url, IDs)
+        .then(data => {
+          if (data.ErrorMessages != null) {
+            console.log(data.ErrorMessages)
+            store.dispatch('flashMessage/set', {
+              type: 'warning',
+              message: 'Failed to get data ...'
+            })
+          }
+          this[targetOptions] = data
+        })
       }
-      this.GetCategoryOptions(url, IDs)
-      .then(data => {
-        if (data.ErrorMessages != null) {
-          console.log(data.ErrorMessages)
-          store.dispatch('flashMessage/set', {
-            type: 'warning',
-            message: 'Failed to get data ...'
-          })
-        }
-        this[targetOptions] = data
-      })
-    },
-    SetQueryParamsFromSearchConditions (searchConditions) {
-      const query = this.RemoveEmptyValue(searchConditions)
-      this.$router.push({ query: query })
     },
     MakeQueryStringFromSearchConditions () {
       const queryString = Object.keys(this.searchConditions)
@@ -79,31 +75,21 @@ export default {
       .join('&')
       return queryString
     },
-    ParseQueryAndSetSearchConditions () {
-      const params = this.$route.query
-      let queryParams = Object.assign({}, params)
-      const selectedIDsKeys = [
-        'selectedQuizLevelIDs',
-        'selectedQuizSectionIDs',
-        'selectedQuizTitleIDs',
-      ]
-      selectedIDsKeys.forEach(key => {
-        if (Array.isArray(queryParams[key])) {
-          queryParams[key] = queryParams[key].map(Number)
-        } else if (queryParams[key] != null){
-          queryParams[key] = [Number(queryParams[key])]
-        }
-      })
-      const paginationKeys = ["page", "pageSize"]
-      paginationKeys.forEach(key => {
-        queryParams[key] = Number(queryParams[key])
-      })
-      Object.assign(this.searchConditions, queryParams)
-    },
     setInitialOptionsForSearchSelect(url, target, ids) {
         if (this[target].length === 0 && ids.length > 0) {
           this.SetCategoryOptionsForSelect(url, target, ids)
         }
+    },
+    IsFormValuesChanged(formValuesBeforeEdit, formValues, formKeys) {
+      var result = false
+  
+      formKeys.forEach(key => {
+        if (formValuesBeforeEdit[key] != formValues[key]) {
+          result = true
+        }
+      })
+  
+      return result
     }
   }
 }


### PR DESCRIPTION
## チケットへのリンク
なし

## やったこと
1. MySearch コンポーネントにて、search ボタン押下後にデフォルトの処理でなく、props で受け取った関数も実行できるようにした。
デフォルトの処理では、検索条件を url クエリパラメータに追加するが、検索条件を url クエリパラメータに追加したくない場面でも MySearch コンポーネントを流用できるようになった。

2. ポップアップを開いた状態で、フラッシュメッセージを表示させると、フラッシュメッセージがポップアップの後ろに隠れてしまうバグを修正。

3. MyDataTable コンポーネントを使用したページにて、ブラウザバック・ブラウザフォワードを行うと、検索条件フォームの値や一覧テーブルのデータが正常に更新されないバグを修正。


<!-- このプルリクで何をしたのか？ -->

## やらないこと

<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## できるようになること（ユーザ目線）
1. ポップアップを開いた状態でも、フラッシュメッセージを確認できるようになる。
2. 一覧画面にて、ブラウザバック・ブラウザフォワードを行っても、正常な一覧テーブルの情報を確認できる。
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## できなくなること（ユーザ目線）

<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認
1.quiz title 詳細ページにて、既存のquiz を追加する一覧テーブルの MySearch コンポーネントに prop で検索条件を url のクエリパラメータとして追加し、ajax 通信する処理を渡した。
実際に、quiz title 詳細ページで、ADD EXISITING QUIZ ボタンを押し、既存の quiz を条件検索したところ、デフォルトの処理ではなく、 prop で渡した関数が実行された。
2. 一覧ページにて条件検索を行い、その後ブラウザバック・ブラウザフォワードで正常に検索条件と一覧テーブルのデータが更新されることを確認。
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

## その他
なし
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
