### PR TITLE
[add] close #43 quiz 一覧ページにて、どの quiz title とも紐付けがない quiz を検索する機能を追加

### DIFF
--- a/src/components/parts/form/MyCheckbox.vue
+++ b/src/components/parts/form/MyCheckbox.vue
@@ -1,0 +1,26 @@
+<template>
+  <v-checkbox
+    v-model="inputValue"
+    :label="label"
+  />
+</template>
+
+<script>
+export default {
+  name: "MyInput",
+  props: {
+    value: { type: [ Boolean, String, Number ], required: true },
+    label: { type: String },
+  },
+  computed: {
+    inputValue: {
+      get() {
+        return this.value
+      },
+      set(value) {
+        this.$emit("input", value)
+      }
+    }
+  }
+}
+</script>

--- a/src/views/admin/quiz-title/AddExistingQuizTable.vue
+++ b/src/views/admin/quiz-title/AddExistingQuizTable.vue
@@ -70,7 +70,11 @@
             multiple
             chips
             clearable
-            />
+          />
+          <my-checkbox
+            v-model="searchConditions.notLinkedToAnyQuizTitles"
+            label="Not linked to any Quiz Titles"
+          />
         </template>
       </MySearch>
       <v-data-table
@@ -149,11 +153,13 @@ import { mapActions } from 'vuex'
 import mixin from '../../../mixins/globalMethods.js'
 import MySearch from '../../../components/parts/search/MySearch'
 import MySelect from '../../../components/parts/form/MySelect'
+import MyCheckbox from '../../../components/parts/form/MyCheckbox'
 export default {
   name: 'MyDataTable',
   components: {
     MySearch,
     MySelect,
+    MyCheckbox
   },
   mixins: [mixin],
   props: {
@@ -171,6 +177,7 @@ export default {
     quizTitleOptionsForSearch: [],
     defaultSearchConditions: {
       page: 1,
+      notLinkedToAnyQuizTitles: false,
       selectedQuizLevelIDs: [],
       selectedQuizSectionIDs: [],
       selectedQuizTitleIDs: [],
@@ -184,6 +191,7 @@ export default {
     },
     searchConditions: {
       page: 1,
+      notLinkedToAnyQuizTitles: false,
       keywords: '',
       selectedQuizLevelIDs: [],
       selectedQuizSectionIDs: [],
@@ -264,10 +272,17 @@ export default {
     }
   },
   watch: {
+    'searchConditions.notLinkedToAnyQuizTitles': function (val) {
+      if (val === true) {
+        this.searchConditions.selectedQuizLevelIDs = []
+      }
+    },
     'searchConditions.selectedQuizLevelIDs': function (val) {
       if (val.length === 0) {
         this.searchConditions.selectedQuizSectionIDs = []
         this.searchConditions.selectedQuizTitleIDs = []
+      } else {
+        this.searchConditions.notLinkedToAnyQuizTitles = false
       }
     },
     'searchConditions.selectedQuizSectionIDs': function (val) {

--- a/src/views/admin/quiz/index.vue
+++ b/src/views/admin/quiz/index.vue
@@ -51,7 +51,11 @@
         multiple
         chips
         clearable
-        />
+      />
+      <my-checkbox
+        v-model="searchConditions.notLinkedToAnyQuizTitles"
+        label="Not linked to any Quiz Titles"
+      />
     </template>
     <template v-slot:form="slotProps">
       <div v-if="slotProps.editedIndex === -1">
@@ -129,13 +133,15 @@ import MyDataTable from '../../../components/parts/dataTable/MyDataTable'
 import MySelect from '../../../components/parts/form/MySelect'
 import MyInput from '../../../components/parts/form/MyInput'
 import MyTextarea from '../../../components/parts/form/MyTextarea'
+import MyCheckbox from '../../../components/parts/form/MyCheckbox'
 export default {
   name: 'IndexQuizTitles',
   components: {
     MyDataTable,
     MySelect,
     MyInput,
-    MyTextarea
+    MyTextarea,
+    MyCheckbox
   },
   mixins: [mixin],
   data: () => ({
@@ -224,6 +230,7 @@ export default {
     quizTitleOptionsForSearch: [],
     defaultSearchConditions: {
       page: 1,
+      notLinkedToAnyQuizTitles: false,
       selectedQuizLevelIDs: [],
       selectedQuizSectionIDs: [],
       selectedQuizTitleIDs: [],
@@ -237,6 +244,7 @@ export default {
     },
     searchConditions: {
       page: 1,
+      notLinkedToAnyQuizTitles: false,
       keywords: '',
       selectedQuizLevelIDs: [],
       selectedQuizSectionIDs: [],
@@ -250,15 +258,29 @@ export default {
     }
   }),
   watch: {
+    'searchConditions.notLinkedToAnyQuizTitles': function (val) {
+      if (val === true) {
+        this.searchConditions.selectedQuizLevelIDs = []
+      }
+    },
     'searchConditions.selectedQuizLevelIDs': function (val) {
       if (val.length === 0) {
         this.searchConditions.selectedQuizSectionIDs = []
         this.searchConditions.selectedQuizTitleIDs = []
+      } else {
+        this.searchConditions.notLinkedToAnyQuizTitles = false
       }
     },
     'searchConditions.selectedQuizSectionIDs': function (val) {
       if (val.length === 0) {
         this.searchConditions.selectedQuizTitleIDs = []
+      } else {
+        this.searchConditions.notLinkedToAnyQuizTitles = false
+      }
+    },
+    'searchConditions.selectedQuizTitleIDs': function (val) {
+      if (val.length != 0) {
+        this.searchConditions.notLinkedToAnyQuizTitles = false
       }
     },
     'editedItem.QuizLevelID': function (val) {

--- a/src/views/admin/quiz/index.vue
+++ b/src/views/admin/quiz/index.vue
@@ -274,13 +274,6 @@ export default {
     'searchConditions.selectedQuizSectionIDs': function (val) {
       if (val.length === 0) {
         this.searchConditions.selectedQuizTitleIDs = []
-      } else {
-        this.searchConditions.notLinkedToAnyQuizTitles = false
-      }
-    },
-    'searchConditions.selectedQuizTitleIDs': function (val) {
-      if (val.length != 0) {
-        this.searchConditions.notLinkedToAnyQuizTitles = false
       }
     },
     'editedItem.QuizLevelID': function (val) {


### PR DESCRIPTION
## チケットへのリンク

#43 

## やったこと
1. checkbox のコンポーネントを追加
2. 以下の２箇所にある条件検索欄にチェックボックス(not linked to any quiz titles)を追加し、チェックして検索した場合、quiz title に紐付かない quiz を取得する
・quiz 一覧画面のテーブル
・quiz title 詳細画面にある Add exisiting quizzes のテーブル
3. watch で 上記のチェックボックスをチェック状態を検知し、true なら level などのカテゴリー選択の値を空にする処理を追加
4. カテゴリーが選択された場合は、上記のチェックボックスの値を false にする処理を追加
<!-- このプルリクで何をしたのか？ -->

## やらないこと
なし
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## できるようになること（ユーザ目線）
どの quiz title とも紐付かない quiz を検索できるようになった。
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## できなくなること（ユーザ目線）

<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認
not linked to any quiz titles のチェックボックス をチェックして、search ボタンを押下
結果：どの quiz title にも紐付かない quiz を取得できた
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

## UI変更
#### 変更後のキャプチャ
・quiz 一覧画面
![スクリーンショット 2021-09-22 5 09 36](https://user-images.githubusercontent.com/48712267/134240519-8d17a4f4-9113-4a5b-b89a-f02eddb8296d.png)

・quiz title 詳細画面の add existing quizzes ポップアップ
![スクリーンショット 2021-09-22 5 09 45](https://user-images.githubusercontent.com/48712267/134240497-826f5c24-034e-4300-a288-7e9b92e245b7.png)

## その他
なし
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
