### PR TITLE
[fix] close #50 MyDataTable コンポーネントのアイテム作成ボタンなどの位置をレスポンシブにする

### DIFF
--- a/src/components/parts/dataTable/MyDataTable.vue
+++ b/src/components/parts/dataTable/MyDataTable.vue
@@ -42,104 +42,112 @@
         class="mytable"
       >
         <template v-slot:top>
-          <v-toolbar flat class="mb-4">
-            <v-dialog
-              v-model="dialog"
-              max-width="600px"
-            >
-              <template v-slot:activator="{ on, attrs }">
-                <v-btn
-                  small
-                  color="primary"
-                  v-bind="attrs"
-                  v-on="on"
-                  class="mr-4"
-                >
-                  New
-                </v-btn>
-              </template>
-              <v-card>
-                <v-card-title>
-                  <span class="text-h5">{{ formTitle }} {{ title }}</span>
-                </v-card-title>
-                <v-card-text>
-                  <v-container>
-                    <ErrorMessages :errorMessages=errorMessages></ErrorMessages>
-                    <v-form ref="form">
-                      <slot name="form" v-bind:editedIndex="editedIndex" ></slot>
-                    </v-form>
-                  </v-container>
-                </v-card-text>
-                <v-card-actions>
-                  <v-spacer></v-spacer>
+          <div
+            class="d-flex flex-column-reverse flex-md-row justify-space-between my-6 mx-2">
+            <div class="d-flex flex-wrap justify-start table-action">
+              <v-dialog
+                v-model="dialog"
+                max-width="600px"
+              >
+                <template v-slot:activator="{ on, attrs }">
                   <v-btn
-                    color="blue darken-1"
-                    text
-                    @click="close"
+                    small
+                    color="primary"
+                    v-bind="attrs"
+                    v-on="on"
+                    class="mr-4 mb-3 mb-md-0"
                   >
-                    Cancel
+                    New
                   </v-btn>
-                  <v-btn
-                    v-if="editedIndex != -1"
-                    color="blue darken-1"
-                    text
-                    @click="update"
-                  >
-                    Update
-                  </v-btn>
-                  <v-btn
-                    v-if="editedIndex === -1"
-                    color="blue darken-1"
-                    text
-                    @click="create"
-                  >
-                    create
-                  </v-btn>
-                </v-card-actions>
-              </v-card>
-            </v-dialog>
-            <v-btn
-              small
-              color="error"
-              @click="deleteItems"
-              :disabled="!deleteBtn"
-              class="mr-4"
-            >
+                </template>
+                <v-card>
+                  <v-card-title>
+                    <span class="text-h5">{{ formTitle }} {{ title }}</span>
+                  </v-card-title>
+                  <v-card-text>
+                    <v-container>
+                      <ErrorMessages :errorMessages=errorMessages></ErrorMessages>
+                      <v-form ref="form">
+                        <slot name="form" v-bind:editedIndex="editedIndex" ></slot>
+                      </v-form>
+                    </v-container>
+                  </v-card-text>
+                  <v-card-actions>
+                    <v-spacer></v-spacer>
+                    <v-btn
+                      color="blue darken-1"
+                      text
+                      @click="close"
+                    >
+                      Cancel
+                    </v-btn>
+                    <v-btn
+                      v-if="editedIndex != -1"
+                      color="blue darken-1"
+                      text
+                      @click="update"
+                    >
+                      Update
+                    </v-btn>
+                    <v-btn
+                      v-if="editedIndex === -1"
+                      color="blue darken-1"
+                      text
+                      @click="create"
+                    >
+                      create
+                    </v-btn>
+                  </v-card-actions>
+                </v-card>
+              </v-dialog>
+              <v-btn
+                small
+                color="error"
+                @click="deleteItems"
+                :disabled="!deleteBtn"
+                class="mr-4 mb-3 mb-md-0"
+              >
               <v-icon left>
                 mdi-trash-can-outline
               </v-icon>
-              Delete items
-            </v-btn>
-            <slot name="btn" v-bind:selectedItems="selectedItems"></slot>
-            <v-spacer></v-spacer>
-            <span class="d-none d-sm-flex mr-3 text-caption grey--text text--darken-3">
-              viewing {{ viewingCount }} of {{ itemsTotalCount }} results
-            </span>
-            <span class="d-none d-sm-flex text-caption font-weight-bold grey--text text--darken-2">
-              Page Size
-            </span>
-            <span class="d-none d-sm-flex ml-2" style="width: 65px;">
-              <MySelect
-                v-model="searchConditions.pageSize"
-                :items="[10, 20, 30, 50, 70, 100]"
-                required
-                dense
-                hide-details
-                @change="changePageSize()"
-              />
-            </span>
-            <v-dialog v-model="dialogDelete" max-width="600px">
-              <v-card>
-                <v-card-title class="text-h5">Are you sure you want to delete those items?</v-card-title>
-                <v-card-actions>
-                  <v-spacer></v-spacer>
-                  <v-btn color="blue darken-1" text @click="closeDelete">Cancel</v-btn>
-                  <v-btn color="blue darken-1" text @click="deleteItemsConfirm(defaultPath)">OK</v-btn>
-                  <v-spacer></v-spacer>
-                </v-card-actions>
-              </v-card>
-            </v-dialog>
-          </v-toolbar>
+                Delete items
+              </v-btn>
+              <v-dialog
+                v-model="dialogDelete"
+                max-width="600px"
+              >
+                <v-card>
+                  <v-card-title class="text-h5">Are you sure you want to delete those items?</v-card-title>
+                  <v-card-actions>
+                    <v-spacer></v-spacer>
+                    <v-btn color="blue darken-1" text @click="closeDelete">Cancel</v-btn>
+                    <v-btn color="blue darken-1" text @click="deleteItemsConfirm(defaultPath)">OK</v-btn>
+                    <v-spacer></v-spacer>
+                  </v-card-actions>
+                </v-card>
+              </v-dialog>
+              <slot name="btn" v-bind:selectedItems="selectedItems"></slot>
+            </div>
+            <div class="d-flex flex-wrap md-justify-end mb-3 mb-md-0 table-info">
+              <p class="d-flex mb-0 mr-3 text-caption text-sm-body-1 grey--text text--darken-3">
+                viewing {{ viewingCount }} of {{ itemsTotalCount }} results
+              </p>
+              <v-divider vertical class="d-none d-sm-block mr-2"></v-divider>
+              <p class="d-flex mb-0 text-caption text-sm-body-1 grey--text text--darken-2 page-size">
+                PageSize
+                <span class="pageSize ml-2" style="width: 65px;">
+                  <MySelect
+                    v-model="searchConditions.pageSize"
+                    :items="[10, 20, 30, 50, 70, 100]"
+                    required
+                    dense
+                    hide-details
+                    @change="changePageSize()"
+                  />
+                </span>
+              </p>
+            </div>
+          </div>
         </template>
         <template v-slot:item.CreatedAt="{ item }" v-slot:activator="{ChangeFormat}">
           {{ ChangeFormat(item.CreatedAt, 'yyyy/MM/dd HH:mm') }}
@@ -453,12 +461,19 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss">
 .mytable .text-start, .v-application--is-ltr .mytable .v-data-table__mobile-row__cell{
   max-width: 180px;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+}
+.mytable .table-info, .mytable .table-action, .mytable .page-size {
+  align-items: center;
+}
+
+.mytable .pageSize .v-select {
+  padding-bottom: 8px;
 }
 
 </style>

--- a/src/views/admin/quiz-title/show.vue
+++ b/src/views/admin/quiz-title/show.vue
@@ -86,6 +86,7 @@
             small
             outlined
             color="error"
+            class="mb-3 mb-md-0"
             :disabled="!slotProps.selectedItems.length"
             @click="removeQuizzes(slotProps.selectedItems)"
           >


### PR DESCRIPTION
## チケットへのリンク

#50

## やったこと
1.  MyDataTable の new、delete ボタンと quiz title 詳細画面に表示される remove ボタンをレスポンシブに対応させた。
2. MyDataTable の表示データ数、検索ヒットしたデータ総数、データ表示数を選択するセレクトボックスをスマホ表示時でも表示できるように UI を変えて、レスポンシブに対応させた。
<!-- このプルリクで何をしたのか？ -->

## やらないこと

<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## できるようになること（ユーザ目線）
quiz title 詳細画面にて、スマホ表示でも remove ボタンが見切れない。
また、一覧テーブルがある画面にて、スマホ表示でも以下が表示されるようになった。
1. 表示データ数
2. 検索でヒットしたデータ数
3. 表示データ数を選択するセレクトボックス
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## できなくなること（ユーザ目線）
なし
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認
quiz title 詳細画面にて、ブラウザの幅を狭めたりしてもボタンなどの要素が正常に表示される確認
結果：正常な位置に要素が表示されることを確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

## UI変更
#### 変更前のキャプチャ
![スクリーンショット 2021-09-23 2 17 29](https://user-images.githubusercontent.com/48712267/134394617-41c57964-fae5-4ba1-b6d4-fdf90f1ed699.png)
![スクリーンショット 2021-09-23 2 17 43](https://user-images.githubusercontent.com/48712267/134394646-0f77b328-1d36-46ba-a02f-4a2dcc6e182c.png)

#### 変更後のキャプチャ
![スクリーンショット 2021-09-23 2 20 02](https://user-images.githubusercontent.com/48712267/134394703-ad578f4b-b596-47f8-99c3-f4dafb5b8c46.png)
![スクリーンショット 2021-09-23 2 20 13](https://user-images.githubusercontent.com/48712267/134394980-23363097-5bff-4202-af22-83cb903a24d7.png)


## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
